### PR TITLE
Add a function converts interger between host and network byte order

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,3 +100,17 @@ exports.ntohlStr = function(s, i) {
 	       ((0xff & s.charCodeAt(i + 2)) << 8) |
 	       ((0xff & s.charCodeAt(i + 3)));
 };
+
+/**
+ * Convert a 32-bit quantity (long integer) from network byte order to host byte order (Big-Endian to Little-Endian).
+ *
+ * @param {number} n the long interger to be converted
+ * @returns long interger
+ */
+exports.htonl(n) {
+    ret = ((n & 0xFF000000) >>> 24 >>> 0) |
+     ((n & 0x00FF0000) >>> 16 >> 0) |
+     ((n & 0x0000FF00) >>>  8 >> 0) |
+     ((n & 0x000000FF) >>>  0 >> 0);
+    return (ret >>> 0);
+}


### PR DESCRIPTION
convert values between host and network byte order, return an unsigned interger.
